### PR TITLE
Bug Fixes and RGB Compare

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
         <dependency>
             <groupId>com.drewnoakes</groupId>
@@ -36,6 +37,18 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-tiff -->
+        <dependency>
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-tiff</artifactId>
+            <version>3.4.2</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.twelvemonkeys.imageio/imageio-core -->
+        <dependency>
+            <groupId>com.twelvemonkeys.imageio</groupId>
+            <artifactId>imageio-core</artifactId>
+            <version>3.4.2</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/DeleteMatches.java
+++ b/src/main/java/DeleteMatches.java
@@ -27,7 +27,7 @@ public class DeleteMatches
             while ((line = br.readLine()) != null)
             {
                 line = line.trim();
-                if (StringUtils.isNotEmpty(line) && !StringUtils.startsWith("xxx", line) && !StringUtils.startsWith("***", line))
+                if (StringUtils.isNotEmpty(line) && !StringUtils.startsWith(line,"xxx") && !StringUtils.equals("*******************************************************************************", line))
                 {
                     final File file = new File(line);
                     files.add(file);
@@ -42,9 +42,8 @@ public class DeleteMatches
             try
             {
                 Files.delete(Paths.get(temp.getPath()));
-            } catch (final Exception e)
+            } catch (final Exception ignored)
             {
-                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/io/CacheMemories.java
+++ b/src/main/java/io/CacheMemories.java
@@ -49,6 +49,10 @@ public class CacheMemories
                     System.out.println("Writing Memories to cache at: " + CACHE_NAME);
                     final FileOutputStream fos = new FileOutputStream(CACHE_NAME);
                     final ObjectOutputStream oos = new ObjectOutputStream(fos);
+                    for(final Memory memory : currentMemories)
+                    {
+                        memory.setMatched(false);
+                    }
                     oos.writeObject(currentMemories);
                     oos.close();
                     System.out.println("Done writing to cache...");
@@ -59,6 +63,10 @@ public class CacheMemories
                 System.out.println("Writing Memories to cache at: " + CACHE_NAME);
                 final FileOutputStream fos = new FileOutputStream(CACHE_NAME);
                 final ObjectOutputStream oos = new ObjectOutputStream(fos);
+                for(final Memory memory : currentMemories)
+                {
+                    memory.setMatched(false);
+                }
                 oos.writeObject(currentMemories);
                 oos.close();
                 System.out.println("Done writing to cache...");

--- a/src/main/java/obj/Memory.java
+++ b/src/main/java/obj/Memory.java
@@ -10,7 +10,7 @@ public class Memory implements Serializable
     private static final long serialVersionUID = 6990332356547600903L;
     private String path;
     private String name;
-    private byte[] firstBytes;
+    private int[] firstRgb;
     private int width;
     private int height;
     private File file;
@@ -56,14 +56,14 @@ public class Memory implements Serializable
         this.name = name;
     }
 
-    public byte[] getFirstBytes()
+    public int[] getFirstRgb()
     {
-        return firstBytes;
+        return firstRgb;
     }
 
-    public void setFirstBytes(final byte[] firstBytes)
+    public void setFirstRgb(final int[] firstRgb)
     {
-        this.firstBytes = firstBytes;
+        this.firstRgb = firstRgb;
     }
 
     public File getFile()

--- a/src/main/java/processing/DetermineMatch.java
+++ b/src/main/java/processing/DetermineMatch.java
@@ -34,7 +34,7 @@ public class DetermineMatch
                 test1.getWidth() == test2.getWidth() &&
                 test1.getHeight() == test2.getHeight() &&
                 test1.getSize() == test2.getSize() &&
-                Arrays.equals(test1.getFirstBytes(), test2.getFirstBytes()) || isProbablePictureMatchRAW(test1, test2);
+                Arrays.equals(test1.getFirstRgb(), test2.getFirstRgb()) || isProbablePictureMatchRAW(test1, test2);
     }
 
     /**
@@ -63,7 +63,7 @@ public class DetermineMatch
      * @param test2    Second Memory
      * @return true if duplicate
      */
-    public static boolean isDuplicatePictureMatch(final byte[] tempByte, final File test2)
+    public static boolean isDuplicatePictureMatch(final int[] tempByte, final File test2)
     {
         return tempByte != null && Arrays.equals(tempByte, Shared.returnPixelVal(test2));
     }

--- a/src/main/java/processing/MemoryChecker.java
+++ b/src/main/java/processing/MemoryChecker.java
@@ -22,10 +22,11 @@ public class MemoryChecker
             final ArrayList<Memory> matches = new ArrayList<>();
             int counter = 0;
             //if we have to fully scan the pic, save it so we don't do it each time
-            byte[] tempByte = null;
+            int[] tempByte;
             Memory innerMemory;
             for (final Memory checkMemory : currentMemories)
             {
+                tempByte = null;
                 counter++;
 
                 if (checkMemory.isMatched())
@@ -33,7 +34,7 @@ public class MemoryChecker
                     continue;
                 }
                 matches.clear();
-                for (int iCount = counter + 1; iCount < currentMemories.size(); iCount++)
+                for (int iCount = counter; iCount < currentMemories.size(); iCount++)
                 {
                     innerMemory = currentMemories.get(iCount);
 
@@ -44,11 +45,6 @@ public class MemoryChecker
                     }
                     try
                     {
-                        if (tempByte == null && checkMemory.getMetadata() == null)
-                        {
-                            tempByte = Shared.returnPixelVal(checkMemory.getFile());
-                        }
-
                         if (DetermineMatch.isProbablePictureMatch(checkMemory, innerMemory))
                         {
                             if (tempByte == null && checkMemory.getMetadata() == null)

--- a/src/main/java/processing/MemoryCreate.java
+++ b/src/main/java/processing/MemoryCreate.java
@@ -14,7 +14,6 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 class MemoryCreate implements Runnable
@@ -131,7 +130,11 @@ class MemoryCreate implements Runnable
                     memory.setHeight(image.getHeight());
                     if (memory.getFile().exists())
                     {
-                        memory.setFirstBytes(Arrays.copyOfRange(Shared.returnPixelVal(memory.getFile()), 0, 3));
+                        final int[] rgb = new int[3];
+                        rgb[0] = image.getRGB(0, 0);
+                        rgb[1] = image.getRGB(image.getWidth() / 2, image.getHeight() / 2);
+                        rgb[2] = image.getRGB(image.getWidth() - 1, image.getHeight() - 1);
+                        memory.setFirstRgb(rgb);
                     }
                 } catch (final Exception ioe)
                 {
@@ -151,7 +154,7 @@ class MemoryCreate implements Runnable
                     } catch (final ImageProcessingException | IOException | NullPointerException ipe)
                     {
                         System.out.println("Error loading memory: " + file.getName());
-                        //ipe.printStackTrace();
+                        ipe.printStackTrace();
                     }
                 }
 

--- a/src/main/java/processing/MemoryCreateMeta.java
+++ b/src/main/java/processing/MemoryCreateMeta.java
@@ -149,7 +149,7 @@ class MemoryCreateMeta implements Runnable
                         memory.setHeight(image.getHeight());
                         if (memory.getFile().exists())
                         {
-                            memory.setFirstBytes(Arrays.copyOfRange(Shared.returnPixelVal(memory.getFile()), 0, 3));
+                            memory.setFirstRgb(Arrays.copyOfRange(Shared.returnPixelVal(memory.getFile()), 0, 3));
                         }
                     } catch (final IOException | NullPointerException ipe)
                     {

--- a/src/main/java/processing/RunnableMemoryChecker.java
+++ b/src/main/java/processing/RunnableMemoryChecker.java
@@ -27,7 +27,7 @@ public class RunnableMemoryChecker implements Runnable
             final ArrayList<Memory> matches = new ArrayList<>();
 
             //if we have to fully scan the pic, save it so we don't do it each time
-            byte[] tempByte = null;
+            int[] tempByte = null;
 
             //check that none of the new files match what we already have
             //this makes sure someone doesn't add a file that is already stored
@@ -69,40 +69,43 @@ public class RunnableMemoryChecker implements Runnable
 
             //check that none of the new files match what is coming in the single staged.
             //this makes sure someone doesn't add the same picture twice during import
-            for (final Memory stagedMemory : stagedMemories)
+            if (matches.isEmpty())
             {
-                if (stagedMemory.isMatched() || newMemory.equals(stagedMemory))
+                for (final Memory stagedMemory : stagedMemories)
                 {
-                    continue;
-                }
-
-                try
-                {
-                    if (DetermineMatch.isProbablePictureMatch(newMemory, stagedMemory))
+                    if (stagedMemory.isMatched() || newMemory.equals(stagedMemory))
                     {
-                        if (tempByte == null && newMemory.getMetadata() == null)
-                        {
-                            tempByte = Shared.returnPixelVal(newMemory.getFile());
-                        }
-
-                        if (newMemory.getMetadata() == null && stagedMemory.getMetadata() == null && DetermineMatch.isDuplicatePictureMatch(tempByte, stagedMemory.getFile()))
-                        {
-                            DetermineMatch.setMatchedItems(matches, newMemory, stagedMemory);
-                        }
-                        if (newMemory.getMetadata() != null && stagedMemory.getMetadata() != null && DetermineMatch.isDuplicatePictureMatchRAW(newMemory, stagedMemory))
-                        {
-                            DetermineMatch.setMatchedItems(matches, newMemory, stagedMemory);
-                        }
+                        continue;
                     }
 
-                    if (DetermineMatch.isPossibleVideoMatch(newMemory, stagedMemory) &&
-                            DetermineMatch.isDuplicateVideo(newMemory.getFile().toPath(), stagedMemory.getFile().toPath()))
+                    try
                     {
-                        DetermineMatch.setMatchedItems(matches, newMemory, stagedMemory);
+                        if (DetermineMatch.isProbablePictureMatch(newMemory, stagedMemory))
+                        {
+                            if (tempByte == null && newMemory.getMetadata() == null)
+                            {
+                                tempByte = Shared.returnPixelVal(newMemory.getFile());
+                            }
+
+                            if (newMemory.getMetadata() == null && stagedMemory.getMetadata() == null && DetermineMatch.isDuplicatePictureMatch(tempByte, stagedMemory.getFile()))
+                            {
+                                DetermineMatch.setMatchedItems(matches, stagedMemory, stagedMemory);
+                            }
+                            if (newMemory.getMetadata() != null && stagedMemory.getMetadata() != null && DetermineMatch.isDuplicatePictureMatchRAW(newMemory, stagedMemory))
+                            {
+                                DetermineMatch.setMatchedItems(matches, stagedMemory, stagedMemory);
+                            }
+                        }
+
+                        if (DetermineMatch.isPossibleVideoMatch(newMemory, stagedMemory) &&
+                                DetermineMatch.isDuplicateVideo(newMemory.getFile().toPath(), stagedMemory.getFile().toPath()))
+                        {
+                            DetermineMatch.setMatchedItems(matches, stagedMemory, stagedMemory);
+                        }
+                    } catch (final Exception e)
+                    {
+                        e.printStackTrace();
                     }
-                } catch (final Exception e)
-                {
-                    e.printStackTrace();
                 }
             }
 

--- a/src/main/java/processing/Shared.java
+++ b/src/main/java/processing/Shared.java
@@ -1,8 +1,8 @@
 package processing;
 
+
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferByte;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
@@ -14,19 +14,19 @@ public class Shared
      * @param fileIn The file to process
      * @return byte array of the picture
      */
-    public static byte[] returnPixelVal(final File fileIn)
+    public static int[] returnPixelVal(final File fileIn)
     {
         final BufferedImage img;
         final File file;
-        byte[] pixels = null;
+        int[] pixels = null;
         try
         {
             file = fileIn;
             img = ImageIO.read(file);
-            pixels = ((DataBufferByte) img.getRaster().getDataBuffer()).getData();
+            pixels = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
         } catch (final Exception e)
         {
-            System.out.println(fileIn.getPath());
+            System.out.println("Exception in return Pixel Val with :" + fileIn.getPath());
             e.printStackTrace();
         }
 


### PR DESCRIPTION
Fixed a few bugs in some files.
Updated to compare for now all files with the RGB, improved duplicate detection a good amount. First by determining if it's a possible match, 3 spots are stored for each picture and compared. If they all match, then a full RGB compare between the two happens to determine duplicate. May in another change make an option to compare this way versus metaData only...